### PR TITLE
fix for dpo-voyager #159

### DIFF
--- a/source/assets/WebDAVProvider.ts
+++ b/source/assets/WebDAVProvider.ts
@@ -239,7 +239,7 @@ export default class WebDAVProvider
             type: contentType ? contentType.elements[0].text as string : "",
         };
 
-        let path = new URL(info.url).pathname;
+        let path = new URL(info.url, this._rootUrl).pathname;
         const index = path.indexOf(this._rootPath);
         if (index >= 0) {
             path = path.substr(index + this._rootPath.length);


### PR DESCRIPTION
See https://github.com/Smithsonian/dpo-voyager/issues/159

This fix takes care that repsonses from a webdav server are interpreted correctly.
The webdav server my include full urls or url-paths in responses.

Before the fix, bare url-paths would cause an error.
After the fix, bare url-paths are combined with the root url.

This single fix will remedy a blocking error that caused voyager-story not being able to handle articles (viewing, editing, saving) in case it worked with a webdav server that returns bare url-paths in its responses.