### PR TITLE
full support for every light sources

### DIFF
--- a/source/components/CAmbientLight.ts
+++ b/source/components/CAmbientLight.ts
@@ -1,0 +1,23 @@
+import { AmbientLight } from "three";
+
+import { Node } from "@ff/graph/Component";
+
+import CLight from "./CLight";
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+export default class CAmbientLight extends CLight
+{
+    static readonly typeName: string = "CAmbientLight";
+
+    constructor(node: Node, id: string)
+    {
+        super(node, id);
+        this.object3D = new AmbientLight();
+    }
+
+    get light(): AmbientLight {
+        return this.object3D as AmbientLight;
+    }
+}

--- a/source/components/CDirectionalLight.ts
+++ b/source/components/CDirectionalLight.ts
@@ -60,6 +60,8 @@ export default class CDirectionalLight extends CLight
             const halfSize = ins.shadowSize.value * 0.5;
             camera.left = camera.bottom = -halfSize;
             camera.right = camera.top = halfSize;
+            camera.near = 0.05*ins.shadowSize.value;
+            camera.far = 50*ins.shadowSize.value;
             camera.updateProjectionMatrix();
         }
 

--- a/source/components/CHemisphereLight.ts
+++ b/source/components/CHemisphereLight.ts
@@ -1,0 +1,44 @@
+
+import { HemisphereLight } from "three";
+
+import { Node, types } from "@ff/graph/Component";
+
+import CLight from "./CLight";
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+export default class CHemisphereLight extends CLight
+{
+    static readonly typeName: string = "CHemisphereLight";
+
+    protected static readonly hemiLightIns = {
+        ground: types.ColorRGB("Light.Ground", [ 0.31, 0.31, 0.125]),
+    };
+
+    ins = this.addInputs<CLight, typeof CHemisphereLight["hemiLightIns"]>(CHemisphereLight.hemiLightIns);
+
+    constructor(node: Node, id: string)
+    {
+        super(node, id);
+        this.object3D = new HemisphereLight();
+    }
+
+    get light(): HemisphereLight {
+        return this.object3D as HemisphereLight;
+    }
+    update(context)
+    {
+        super.update(context);
+
+        const light = this.light;
+        const ins = this.ins;
+
+        if (ins.ground.changed || ins.intensity.changed) {
+            light.groundColor.fromArray(ins.ground.value);
+            light.intensity = ins.intensity.value;
+        }
+        return true;
+    }
+
+}

--- a/source/components/CLight.ts
+++ b/source/components/CLight.ts
@@ -7,7 +7,7 @@
 
 import { Light } from "three";
 
-import { types } from "@ff/graph/propertyTypes";
+import { Node, types } from "@ff/graph/Component";
 import CObject3D from "./CObject3D";
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -51,12 +51,16 @@ export default class CLight extends CObject3D
             light.intensity = ins.intensity.value;
         }
 
-        if (ins.shadowEnabled.changed || (ins.shadowEnabled.value && (
-            ins.shadowResolution.changed || ins.shadowBlur.changed))) {
+        //some lights, like ambient and hemisphere light don't have shadows
+        if("shadow" in light){
+            if (ins.shadowEnabled.changed) {
+                light.castShadow = ins.shadowEnabled.value;
+            }
 
-            light.castShadow = ins.shadowEnabled.value;
-            light.shadow.radius = ins.shadowBlur.value;
-
+            if(ins.shadowBlur.changed){
+                light.shadow.radius = ins.shadowBlur.value;
+            }
+                
             if (ins.shadowResolution.changed) {
                 const mapResolution = _mapResolution[ins.shadowResolution.getValidatedValue()];
                 light.shadow.mapSize.set(mapResolution, mapResolution);

--- a/source/components/CPointLight.ts
+++ b/source/components/CPointLight.ts
@@ -52,6 +52,8 @@ export default class CPointLight extends CLight
         if (ins.distance.changed || ins.decay.changed) {
             light.distance = ins.distance.value;
             light.decay = ins.decay.value;
+            //PointLightShadow doesn't handle camera.near for us, but will set camera.far and update the projection matrix
+            light.shadow.camera.near = light.distance?light.distance/800 : 0.5;
         }
 
         light.updateMatrix();

--- a/source/components/CRectLight.ts
+++ b/source/components/CRectLight.ts
@@ -1,0 +1,49 @@
+
+import { Object3D, RectAreaLight, Vector3 } from "three";
+
+import { Node, types } from "@ff/graph/Component";
+
+import CLight from "./CLight";
+
+////////////////////////////////////////////////////////////////////////////////
+
+export default class CRectLight extends CLight
+{
+    static readonly typeName: string = "CRectLight";
+
+    protected static readonly rectLightIns = {
+        position: types.Vector3("Light.Position", [ 0, 1, 0 ]),
+        target: types.Vector3("Light.Target", [ 0, 0, 0 ]),
+        size: types.Vector2("Light.Size", [10, 10]),
+    };
+
+    ins = this.addInputs<CLight, typeof CRectLight["rectLightIns"]>(CRectLight.rectLightIns);
+
+    constructor(node: Node, id: string)
+    {
+        super(node, id);
+
+        this.object3D = new RectAreaLight();
+        
+    }
+
+    get light(): RectAreaLight {
+        return this.object3D as RectAreaLight;
+    }
+
+    update(context)
+    {
+        super.update(context);
+
+        const light = this.light;
+        const ins = this.ins;
+
+        if (ins.position.changed || ins.target.changed) {
+            light.position.fromArray(ins.position.value);
+            light.updateMatrix();
+        }
+
+
+        return true;
+    }
+}

--- a/source/components/CSpotLight.ts
+++ b/source/components/CSpotLight.ts
@@ -59,6 +59,9 @@ export default class CSpotLight extends CLight
             light.decay = ins.decay.value;
             light.angle = ins.angle.value * MathUtils.DEG2RAD;
             light.penumbra = ins.penumbra.value;
+
+            //SpotLightShadow doesn't handle camera.near for us, but will set camera.far and update the projection matrix
+            light.shadow.camera.near = light.distance? light.distance/800 : 0.5;
         }
 
         return true;


### PR DESCRIPTION
Add support for `PointLight`, `SpotLight`, `AmbientLight`,`HemisphereLight` and `RectAreaLight`. See https://github.com/Smithsonian/dpo-voyager/pull/215.

It enables `physicallyCorrectLights` (as advised in THREE manual), that's supposedly a breaking change but I couldn't find a case where it made a significant visual difference.